### PR TITLE
1.5

### DIFF
--- a/Config/VRConfig.cs
+++ b/Config/VRConfig.cs
@@ -8,6 +8,8 @@ public class VRConfig
     //UI settings
     public static ConfigEntry<float> uiDistance;
     public static ConfigEntry<bool> taskGradient;
+    public static ConfigEntry<float> uiScale;
+    public static ConfigEntry<float> uiHeightOffset;
 
     //Controls settings
     public static ConfigEntry<bool> useHeadMovement;
@@ -27,7 +29,11 @@ public class VRConfig
     {
         uiDistance = VSVRMod.config.Bind("UI", "UI Distance", 0.5f, "How far away the UI appears from your face in meters.\n" +
             "The relative size will not change, i.e. if you make it closer to you it will also become smaller such that it takes up the same FOV.");
-        taskGradient = VSVRMod.config.Bind("UI", "Task Gradient", true, "Enable or disable the semitransparent gradient behind the task text");
+        taskGradient = VSVRMod.config.Bind("UI", "Task Gradient", true, "Enable or disable the semitransparent gradient behind the task text. May not work in all circumstances.");
+        uiScale = VSVRMod.config.Bind("UI", "UI Scale", 1.0f, "Scale the overall size of the UI up or down." +
+            "\nLowering this could be helpful if some UI elements are difficult to see in your headset due to limited FOV.");
+        uiHeightOffset = VSVRMod.config.Bind("UI", "UI Height Offset", 0f, "Vertically moves the UI. 10 units corresponds to about 1 degree in VR." +
+            "\nChanging this could be helpful if some UI elements are difficult to see in your headset due to limited FOV.");
 
         useHeadMovement = VSVRMod.config.Bind("Controls", "Use Head Movement", true, "Enable or disable the ability to press buttons by nodding or shaking your head.");
         automaticScreenSwap = VSVRMod.config.Bind("Controls", "Automatic Screen Swap", true, "Automatically swap the game output to your monitor when your headset is removed. Only works on Oculus and WMR headsets.");

--- a/Controls/Controller.cs
+++ b/Controls/Controller.cs
@@ -9,7 +9,7 @@ using UnityEngine.XR.OpenXR.Features.Interactions;
 
 namespace VSVRMod2;
 
-class Controller
+public class Controller
 {
     public static int outputControllerDebug = 0;
     private static UnityEngine.XR.InputDevice leftController;
@@ -356,6 +356,8 @@ class Controller
 
         private bool lastState = true;
 
+        public float lastPutOn = 0f;
+
         public void Update()
         {
             bool worn = IsHeadsetWorn();
@@ -364,6 +366,7 @@ class Controller
                 if(worn)
                 {
                     OnWorn?.Invoke();
+                    lastPutOn = Time.time;
                 }
                 else
                 { 

--- a/Controls/Controller.cs
+++ b/Controls/Controller.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
-using UnityEngine.PlayerLoop;
 using UnityEngine.XR;
 using UnityEngine.XR.OpenXR;
 using UnityEngine.XR.OpenXR.Features;
@@ -426,7 +425,7 @@ class Controller
         return maximal.magnitude;
     }
 
-    public static void endFrame()
+    public static void EndFrame()
     {
         lastStickStatus = IsAStickPressed();
         lastFaceStatus = IsAFaceButtonPressed();

--- a/Controls/Keyboard.cs
+++ b/Controls/Keyboard.cs
@@ -17,6 +17,8 @@ class Keyboard
         }
     }
 
+    private static bool r1 = true;
+
     public static void HandleKeyboardInput()
     {
         if (Input.GetKeyDown(KeyCode.Quote))
@@ -27,6 +29,11 @@ class Keyboard
         if (Input.GetKeyDown(KeyCode.Period))
         {
             Controller.CheckControllers();
+        }
+        if(Input.GetKeyDown(KeyCode.PageUp) && r1)
+        {
+            r1 = false;
+            VSVRMod.instance.InitialSessionSetup();
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,7 +31,7 @@ public class VSVRMod : BaseUnityPlugin
     private static UIContainer uiContainer;
     private static StartUIManager beginUiManager;
 
-    private static readonly Controller.Headset controllerHeadset = new();
+    public static readonly Controller.Headset controllerHeadset = new();
 
     private static bool noVR = false;
 

--- a/UI/BasicUI.cs
+++ b/UI/BasicUI.cs
@@ -128,6 +128,10 @@ public class BasicUIManager : UIManager
 
         public void Nod()
         {
+            if (!Controller.IsHeadsetWorn())
+            {
+                return;
+            }
             headshakes = 0;
             if (MathHelper.CurrentTimeMillis() - lastNodTime > 1000)
             {
@@ -144,6 +148,10 @@ public class BasicUIManager : UIManager
         }
         public void Headshake()
         {
+            if (!Controller.IsHeadsetWorn())
+            {
+                return;
+            }
             nods = 0;
             if (MathHelper.CurrentTimeMillis() - lastHeadshakeTime > 1000)
             {

--- a/UI/BasicUI.cs
+++ b/UI/BasicUI.cs
@@ -119,6 +119,8 @@ public class BasicUIManager : UIManager
         long lastNodTime;
         long lastHeadshakeTime;
 
+        const float GRACE_SECONDS = 2.0f;
+
         BasicUIManager basicUIManager;
 
         public HeadMovementTracker(BasicUIManager basicUIManager)
@@ -128,7 +130,7 @@ public class BasicUIManager : UIManager
 
         public void Nod()
         {
-            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - 5.0f)
+            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - GRACE_SECONDS)
             {
                 return;
             }
@@ -148,7 +150,7 @@ public class BasicUIManager : UIManager
         }
         public void Headshake()
         {
-            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - 5.0f)
+            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - GRACE_SECONDS)
             {
                 return;
             }

--- a/UI/BasicUI.cs
+++ b/UI/BasicUI.cs
@@ -128,7 +128,7 @@ public class BasicUIManager : UIManager
 
         public void Nod()
         {
-            if (!Controller.IsHeadsetWorn())
+            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - 5.0f)
             {
                 return;
             }
@@ -148,7 +148,7 @@ public class BasicUIManager : UIManager
         }
         public void Headshake()
         {
-            if (!Controller.IsHeadsetWorn())
+            if (!Controller.IsHeadsetWorn() || VSVRMod.controllerHeadset.lastPutOn > Time.time - 5.0f)
             {
                 return;
             }

--- a/UI/FindomUI.cs
+++ b/UI/FindomUI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine.SceneManagement;
 using UnityEngine;
 using UnityEngine.UI;
+using System.IO;
 
 namespace VSVRMod2.UI;
 
@@ -51,6 +52,11 @@ public class FindomUIManager : UIManager
         findomInput.sendOptions.Add(placateButton);
         findomInput.sendOptions.Add(bribeButton);
         findomInput.sendOptions.Add(tributeButton);
+
+        //weird thingy dunno why its even there? not related
+        VSVRMod.logger.LogInfo("Hiding weird thing in Tribute Menu");
+        Transform annoyingThing = overlayCanvas.transform.Find("TributeMenu/Slider - Standard (Value)/Text (TMP) (7)/Image");
+        annoyingThing.gameObject.SetActive(false);
 
         VSVRMod.logger.LogInfo("Setup Tribute Menu");
     }

--- a/UI/StartUI.cs
+++ b/UI/StartUI.cs
@@ -17,7 +17,7 @@ public class StartUIManager
     {
         if (Controller.WasAFaceButtonClicked())
         {
-            GameObject preparationMenu = GameObject.Find("Pre-Game/MainMenu/Camera Canvas/MenuManager/PreparationMenu");
+            GameObject preparationMenu = GameObject.Find("Pre-Game/MainMenu/Camera Canvas/MenuManager/FinalChecksMenu/SessionReady/ButtonContainer (1)");
             if (preparationMenu == null || !preparationMenu.activeSelf) {
                 VSVRMod.logger.LogWarning("Not in preparation menu, this may be expected.");
             }

--- a/VRCamera/VRCamera.cs
+++ b/VRCamera/VRCamera.cs
@@ -388,6 +388,11 @@ public class VRCameraManager
         foreach (GameObject bg in bgs)
         {
             bg.SetActive(false);
+            PlayMakerFSM fsm = bg.GetComponent<PlayMakerFSM>();
+            if(fsm != null)
+            {
+                fsm.enabled = false;
+            }
         }
     }
 

--- a/VRCamera/VRCamera.cs
+++ b/VRCamera/VRCamera.cs
@@ -25,6 +25,8 @@ public class VRCameraManager
     private GameObject overlay;
     private GameObject ui;
 
+    private static bool isFirstUIAdjust = true;
+
     public VRCameraManager(Scene scene)
     {
         if (scene.isLoaded && Equals(scene.name, Constants.SessionScene))
@@ -247,7 +249,7 @@ public class VRCameraManager
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 1000, 0);
         currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(1f, 1f, 1f);
 
-        currentAdjust = ui.transform.Find("EventManager/ToyChecklist").gameObject;
+/*        currentAdjust = ui.transform.Find("EventManager/ToyChecklist").gameObject;
         if (currentAdjust == null)
         {
             VSVRMod.logger.LogError("ToyChecklist not found");
@@ -257,7 +259,7 @@ public class VRCameraManager
             VSVRMod.logger.LogInfo("ToyChecklist found");
         }
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 480, 0);
-        currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.2f, 0.2f, 0.2f);
+        currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.2f, 0.2f, 0.2f);*/
 
         currentAdjust = ui.transform.Find("EventManager/TradeOfferUI").gameObject;
         if (currentAdjust == null)
@@ -294,6 +296,8 @@ public class VRCameraManager
         }
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 560, 0);
         currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.7f, 0.7f, 0.7f);
+        currentAdjust.transform.localScale *= VRConfig.uiScale.Value;
+        currentAdjust.transform.position += new Vector3(0, VRConfig.uiHeightOffset.Value, 0);
 
         currentAdjust = overlay.transform.Find("YourStatusMenuManager").gameObject;
         if (currentAdjust == null)
@@ -317,18 +321,17 @@ public class VRCameraManager
             VSVRMod.logger.LogInfo("ASMROverlay found");
         }
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 750, 0);
-        if(TemporaryFindABetterSolutionLaterPlease)
+        if(isFirstUIAdjust)
         {
             currentAdjust.GetComponent<RectTransform>().localScale = currentAdjust.GetComponent<RectTransform>().localScale * 1.2f;
-            TemporaryFindABetterSolutionLaterPlease = false;
         }
 
         vrCamera.SetActive(true);
         SetupHeadTargetFollower(false);
         worldCamDefaultCamera.enabled = false;
+        isFirstUIAdjust = false;
+        VSVRMod.logger.LogError("Adjusted UI for VR");
     }
-
-    private static bool TemporaryFindABetterSolutionLaterPlease = true;
 
     public void RevertUI()
     {
@@ -349,6 +352,8 @@ public class VRCameraManager
         worldCamDefaultCamera.enabled = true;
         vrCamera.SetActive(false);
         SetupHeadTargetFollower(true);
+
+        VSVRMod.logger.LogInfo("Adjusted UI for monitor");
     }
 
     public void DisableTaskGradient()
@@ -392,10 +397,6 @@ public class VRCameraManager
 
         AddChecked(bgs, "Urges/ActionTextContainer/Image (1)", eventManager);
 
-
-        //weird thingy dunno why its even there?
-        AddChecked(bgs, "TributeMenu/Slider - Standard (Value)/Text (TMP) (7)/Image", overlayCanvas);
-
         foreach (GameObject bg in bgs)
         {
             bg.SetActive(false);
@@ -433,7 +434,7 @@ public class VRCameraManager
         }
         vrCameraOffset.transform.position = vrCamera.transform.position;
         vrCameraOffset.transform.localPosition = -vrCamera.transform.localPosition;
-        vrCameraOffset.transform.rotation = new Quaternion(0, 0, 0, 0);//Quaternion.FromToRotation(Vector3.zero, new Vector3(0, -vrCamera.transform.rotation.y, 0));
+        vrCameraOffset.transform.localEulerAngles = new Vector3(0, -vrCamera.transform.localEulerAngles.y, 0);
     }
 
     private bool didRecenter = false;

--- a/VRCamera/VRCamera.cs
+++ b/VRCamera/VRCamera.cs
@@ -249,17 +249,17 @@ public class VRCameraManager
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 1000, 0);
         currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(1f, 1f, 1f);
 
-/*        currentAdjust = ui.transform.Find("EventManager/ToyChecklist").gameObject;
-        if (currentAdjust == null)
-        {
-            VSVRMod.logger.LogError("ToyChecklist not found");
-        }
-        else
-        {
-            VSVRMod.logger.LogInfo("ToyChecklist found");
-        }
-        currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 480, 0);
-        currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.2f, 0.2f, 0.2f);*/
+        /*        currentAdjust = ui.transform.Find("EventManager/ToyChecklist").gameObject;
+                if (currentAdjust == null)
+                {
+                    VSVRMod.logger.LogError("ToyChecklist not found");
+                }
+                else
+                {
+                    VSVRMod.logger.LogInfo("ToyChecklist found");
+                }
+                currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 480, 0);
+                currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.2f, 0.2f, 0.2f);*/
 
         currentAdjust = ui.transform.Find("EventManager/TradeOfferUI").gameObject;
         if (currentAdjust == null)
@@ -296,8 +296,10 @@ public class VRCameraManager
         }
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 560, 0);
         currentAdjust.GetComponent<RectTransform>().localScale = new Vector3(0.7f, 0.7f, 0.7f);
-        currentAdjust.transform.localScale *= VRConfig.uiScale.Value;
-        currentAdjust.transform.position += new Vector3(0, VRConfig.uiHeightOffset.Value, 0);
+        if (isFirstUIAdjust) {
+            currentAdjust.transform.localScale *= VRConfig.uiScale.Value;
+            currentAdjust.transform.localPosition += new Vector3(0, VRConfig.uiHeightOffset.Value, 0);
+        }
 
         currentAdjust = overlay.transform.Find("YourStatusMenuManager").gameObject;
         if (currentAdjust == null)

--- a/VRCamera/VRCamera.cs
+++ b/VRCamera/VRCamera.cs
@@ -48,6 +48,11 @@ public class VRCameraManager
     {
         worldCamDefault = GameObjectHelper.GetGameObjectCheckFound("WorldCamDefault");
         primaryCamera = GameObjectHelper.GetGameObjectCheckFound("PrimaryCamera");
+        if( worldCamDefault == null ) 
+        {
+            VSVRMod.logger.LogInfo("WorldCamDefault may be disabled, doing fallback method.");
+            worldCamDefault = primaryCamera.transform.Find("WorldCamDefault").gameObject;
+        }
         worldCamDefaultCamera = worldCamDefault.GetComponent<Camera>();
         vrCameraParent = new GameObject("VRCameraParent");
         vrCameraParent.transform.SetParent(worldCamDefault.transform.root);
@@ -312,12 +317,18 @@ public class VRCameraManager
             VSVRMod.logger.LogInfo("ASMROverlay found");
         }
         currentAdjust.GetComponent<RectTransform>().anchoredPosition3D = new Vector3(0, 750, 0);
-        currentAdjust.GetComponent<RectTransform>().localScale = currentAdjust.GetComponent<RectTransform>().localScale * 1.2f;
+        if(TemporaryFindABetterSolutionLaterPlease)
+        {
+            currentAdjust.GetComponent<RectTransform>().localScale = currentAdjust.GetComponent<RectTransform>().localScale * 1.2f;
+            TemporaryFindABetterSolutionLaterPlease = false;
+        }
 
         vrCamera.SetActive(true);
         SetupHeadTargetFollower(false);
         worldCamDefaultCamera.enabled = false;
     }
+
+    private static bool TemporaryFindABetterSolutionLaterPlease = true;
 
     public void RevertUI()
     {
@@ -393,6 +404,11 @@ public class VRCameraManager
             {
                 fsm.enabled = false;
             }
+            Image img = bg.GetComponent<Image>();
+            if (img != null)
+            {
+                img.enabled = false;
+            }
         }
     }
 
@@ -417,7 +433,7 @@ public class VRCameraManager
         }
         vrCameraOffset.transform.position = vrCamera.transform.position;
         vrCameraOffset.transform.localPosition = -vrCamera.transform.localPosition;
-        vrCameraOffset.transform.rotation = new Quaternion(0, 0, 0, 0);
+        vrCameraOffset.transform.rotation = new Quaternion(0, 0, 0, 0);//Quaternion.FromToRotation(Vector3.zero, new Vector3(0, -vrCamera.transform.rotation.y, 0));
     }
 
     private bool didRecenter = false;


### PR DESCRIPTION
Fixed rare bug that could prevent a session from being set up for VR properly
Remove resizing step for checklist, since that is no longer in the session intro
Added even more text background gradients to be disabled when the config option is used.
Fix ASMR overlay getting bigger each time the VR/screen swap is performed
Make camera centering affect camera rotation as well
Head gestures now only work when headset is on. Only headsets with a user presence sensor are affected
 * There is a grace period of five seconds after putting on a headset where gestures will still not be tracked.
Added UI scale and UI vertical offset config options, good to adjust if your headsets FOV makes it hard to see some UI elements

Change begin button reference (not needed in changelog)